### PR TITLE
Declare package dependency on evil, improve package description

### DIFF
--- a/evil-matchit.el
+++ b/evil-matchit.el
@@ -1,4 +1,4 @@
-;;; evil-matchit --- Vim matchit ported into Emacs (requires EVIL)
+;;; evil-matchit --- Vim matchit ported to Evil
 
 ;; Copyright (C) 2013 Chen Bin
 
@@ -6,6 +6,7 @@
 ;; URL: http://github.com/redguardtoo/evil-matchit
 ;; Version: 0.0.3
 ;; Keywords: matchit vim evil
+;; Package-Requires: ((evil "1.0.7"))
 ;;
 ;; This file is not part of GNU Emacs.
 


### PR DESCRIPTION
Also: you can delete the `evil-matchit-pkg.el` file -- neither Marmalade nor MELPA need a `-pkg.el` file for single-file packages, so you can eliminate the redundant info.

Cheers!

-Steve
