### PR TITLE
Fix embedded major-mode detection in org-mode

### DIFF
--- a/evil-matchit-org.el
+++ b/evil-matchit-org.el
@@ -49,17 +49,9 @@ between '\\(' and '\\)' in regular expression.
     ))
 
 (defun evilmi--get-embedded-language-major-mode ()
-  (let ((info (org-edit-src-find-region-and-lang))
-        lang
-        lang-f)
-    (if info
-        (progn
-          (setq lang (or (cdr (assoc (nth 2 info) org-src-lang-modes))
-                         (nth 2 info)))
-          (setq lang (if (symbolp lang) (symbol-name lang) lang))
-          (setq lang-f (intern (concat lang "-mode")))
-          ))
-    lang-f))
+  (let ((lang (org-element-property :language (org-element-at-point))))
+    (when lang
+      (intern (concat lang "-mode")))))
 
 ;;;###autoload
 (defun evilmi-org-get-tag ()


### PR DESCRIPTION
It seems `org-edit-src-find-region-and-lang` is gone in Org 8.3.2. I've scanned the org-mode repo and org-plus-contrib to no avail (aside from two vestigial references, there was no definition). Here is an alternative (perhaps more portable) way to detect the current block's major mode.