### PR TITLE
Ocaml

### DIFF
--- a/evil-matchit-ocaml.el
+++ b/evil-matchit-ocaml.el
@@ -1,0 +1,82 @@
+(setq evilmi-ocaml-keywords
+      '((("struct" "begin" "object") ("end"))
+        (("if") ("then"))
+        (("match") ("with"))
+        (("match" "try") ("with"))
+        (("while" "for") ("done"))
+        (("let") ("in"))
+        ()))
+
+;; regexp to find next/previous keyword
+(setq keywords-regex
+  (let ((all-keywords (apply 'append (apply 'append evilmi-ocaml-keywords))))
+    (format "\\<\\(%s\\)\\>" (mapconcat 'identity all-keywords "\\|"))))
+
+;; jumps to next keyword. Returs nil if there's no next word
+(defun evilmi-ocaml-next-word (direction)
+  (if (= direction 0)
+      (let ((new-point (save-excursion
+          (forward-char)
+          (if (search-forward-regexp keywords-regex nil t)
+              (search-backward-regexp keywords-regex)
+            nil)
+        )))
+        (if new-point (goto-char new-point)))
+    (search-backward-regexp keywords-regex nil t)))
+
+(defun evilmi-ocaml-end-word ()
+  (save-excursion
+    (search-forward-regexp "\\>")
+    (point)))
+
+(defun evilmi-ocaml-get-word ()
+  (buffer-substring-no-properties (point) (evilmi-ocaml-end-word)))
+
+(defun evilmi-ocaml-is-keyword (l keyword)
+  "Checks if the keyword belongs to a row"
+  (find-if (lambda (w) (string-equal w keyword)) (apply 'append l)))
+
+(defun evilmi-ocaml-get-tag-info (keyword)
+  "Find the row in the evilmi-ocaml-keywords"
+  (find-if (lambda (l) (evilmi-ocaml-is-keyword l keyword)) evilmi-ocaml-keywords))
+
+;; 0 - forward
+;; 1 - backward
+(defun evilmi-ocaml-go (tag-info level direction)
+  (if (= level 0)
+      (point)
+    (if (evilmi-ocaml-next-word direction)
+        (progn 
+          (setq keyword (evilmi-ocaml-get-word))
+
+          (if (evilmi-ocaml-is-keyword tag-info keyword)
+              ;; interesting tag
+              (if (member keyword (nth direction tag-info))
+                  (evilmi-ocaml-go tag-info (+ level 1) direction)
+                (evilmi-ocaml-go tag-info (- level 1) direction))
+
+            ;; other tag
+            (evilmi-ocaml-go tag-info level direction)))
+      nil)))
+
+(defun evilmi-ocaml-goto-word-beginning ()
+  ;; this is so that when the cursor is on the first character we don't jump to previous word
+  (forward-char)
+  (search-backward-regexp "\\<"))
+
+;;;###autoload
+(defun evilmi-ocaml-get-tag ()
+  (save-excursion 
+    (evilmi-ocaml-goto-word-beginning)
+    (evilmi-ocaml-get-word)))
+
+;;;###autoload
+(defun evilmi-ocaml-jump (rlt num)
+  (let* ((tag-info (evilmi-ocaml-get-tag-info rlt))
+         (direction (if (member rlt (car tag-info)) 0 1)))
+    (let ((new-point (save-excursion
+                       (evilmi-ocaml-goto-word-beginning)
+                       (evilmi-ocaml-go tag-info 1 direction))))
+      (if new-point (goto-char new-point)))))
+
+(provide 'evil-matchit-ocaml)

--- a/evil-matchit.el
+++ b/evil-matchit.el
@@ -309,6 +309,12 @@ If font-face-under-cursor is NOT nil, the quoted string is being processed."
   (plist-put evilmi-plugins 'latex-mode '((evilmi-latex-get-tag evilmi-latex-jump)
                                           (evilmi-simple-get-tag evilmi-simple-jump)))
 
+  ;; ocaml
+  (autoload 'evilmi-ocaml-get-tag "evil-matchit-ocaml" nil)
+  (autoload 'evilmi-ocaml-jump "evil-matchit-ocaml" nil t)
+  (plist-put evilmi-plugins 'tuareg-mode '((evilmi-ocaml-get-tag evilmi-ocaml-jump)
+                                          (evilmi-simple-get-tag evilmi-simple-jump)))
+
   ;; Python
   (autoload 'evilmi-python-get-tag "evil-matchit-python" nil)
   (autoload 'evilmi-python-jump "evil-matchit-python" nil)


### PR DESCRIPTION
Add initial support for ocaml:
```lisp
        (("struct" "begin" "object") ("end"))
        (("if") ("then"))
        (("match") ("with"))
        (("match" "try") ("with"))
        (("while" "for") ("done"))
        (("let") ("in"))
```

@redguardtoo, I couldn't find any place to add automated tests so there are no tests. Please advise as how you test pull requests.

Also, I'm having some issues with normal parenthesis: if global-evil-matchit-mode is enabled % only works on ocaml keywords (in tuareg buffers). If it's disabled, though, it only works on normal parenthesis. @redguardtoo, could you have a look?

(cc @msaffer, who should be interested in this feature)