### PR TITLE
Add sig/end matching for ocaml

### DIFF
--- a/evil-matchit-ocaml.el
+++ b/evil-matchit-ocaml.el
@@ -1,5 +1,5 @@
 (defvar evilmi-ocaml-keywords
-  '((("struct" "begin" "object") ("end"))
+  '((("struct" "begin" "sig" "object") ("end"))
     (("if") ("then"))
     (("match") ("with"))
     (("match" "try") ("with"))


### PR DESCRIPTION
sig/end is a form used in ocaml's module signature language. 
See https://caml.inria.fr/pub/docs/manual-ocaml/moduleexamples.html#sec19 for more information about the syntax.