### PR TITLE
Ocaml improvements

### DIFF
--- a/evil-matchit-ocaml.el
+++ b/evil-matchit-ocaml.el
@@ -1,3 +1,31 @@
+;;; evil-matchit-ocaml.el -- tuareg-mode  plugin of evil-matchit
+
+;; Copyright (C) 2014-2017 Chen Bin <chenbin.sh@gmail.com>
+
+;; Author: Tomasz Kołodziejski <tkolodziejski@gmail.com>
+
+;; This file is not part of GNU Emacs.
+
+;;; License:
+
+;; This file is part of evil-matchit
+;;
+;; evil-matchit is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; evil-matchit is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+;;; Code:
+
 (defvar evilmi-ocaml-keywords
   '((("struct" "begin" "sig" "object") ("end"))
     (("if") ("then"))

--- a/evil-matchit-ocaml.el
+++ b/evil-matchit-ocaml.el
@@ -61,9 +61,8 @@
       nil)))
 
 (defun evilmi-ocaml-goto-word-beginning ()
-  ;; this is so that when the cursor is on the first character we don't jump to previous word
-  (forward-char)
-  (search-backward-regexp "\\<"))
+  (let ((bounds (bounds-of-thing-at-point 'word)))
+    (if bounds (goto-char (car bounds)))))
 
 ;;;###autoload
 (defun evilmi-ocaml-get-tag ()


### PR DESCRIPTION
Make ocaml's jump behave more like vim's % (see #80):

```vim
:help %
"Find the next item in this line after or under the cursor and jump to its match."
```

E.g.:
```ocaml
module Stable = struct
...
end
```
will jump to end no matter where you put your cursor on the first line.
For this to fully make sense, however, we'd have to fix evil-matchit in other plugins as well, in particular, the simple one as otherwise it misbehaves:

```ocaml
    let n x =
      1 + (match x with
          | X -> 1
          | Y -> 2)
```

If you put your cursor on 1 and hit <kbd>%</kbd> it'll jump to `with`.
I can fix this for ocaml by finding matching parenthesis in the ocaml plugin myself (and not using evil-matchit-simple.el) but I think this should be fixed globally for all of the plugins.

It seems to me that all of the `evilmi-simple-get-tag`-like functions should return the closest point where from which the jump can happen (i.e. for simple the closest parenthesis after or under cursor, for ocaml the closest keyword after or under cursor). I'm not entirely sure if there's specific semantics for what they should return at the moment (I added [a comment](https://github.com/redguardtoo/evil-matchit/commit/0b0e6d61a6462fc6fff7000b739ce5b31acd0d4c#commitcomment-23310907) asking about it). Then evil-matchit should choose the closest one (in the current line) that returned non-nil and do the jump with `evilmi-<the closest one>-jump`.

I would also suggest that we do these changes only after we add some testing framework for this plugin. I only ever used ecukes from [expand-region](https://github.com/magnars/expand-region.el).

What do you think @redguardtoo?