### PR TITLE
Mark evilmi-jump-items as a jump motion

### DIFF
--- a/evil-matchit.el
+++ b/evil-matchit.el
@@ -458,6 +458,7 @@ If IS-FORWARD is t, jump forward; or else jump backward."
 (evil-define-command evilmi-jump-items (&optional num)
   "Jump between items."
   :repeat nil
+  :jump t
   (interactive "P")
   (cond
    ((and evilmi-may-jump-by-percentage num)


### PR DESCRIPTION
vim considers matchit movments as jump motions. Following that convention makes modifying of start/end tags much easier.