### PR TITLE
Silence byte-compiler

### DIFF
--- a/evil-matchit-org.el
+++ b/evil-matchit-org.el
@@ -72,6 +72,8 @@ between '\\(' and '\\)' in regular expression.")
         (setq rlt '(-1)))
     rlt))
 
+(defvar evilmi-plugins)
+
 ;;;###autoload
 (defun evilmi-org-jump (rlt num)
   (cond


### PR DESCRIPTION
evilmi-plugins is defined in evil-matchit.el, which is not loaded by
evil-matchit-org.el.


----

#