### PR TITLE
`evilmi-sdk-simple-jump': skip whitespace

### DIFF
--- a/evil-matchit-sdk.el
+++ b/evil-matchit-sdk.el
@@ -153,6 +153,7 @@ If IS-FORWARD is t, jump forward; or else jump backward."
 (defun evilmi-sdk-simple-jump ()
   "Alternative for `evil-jump-item'."
   (if evilmi-debug (message "evilmi-sdk-simple-jump called (point)=%d" (point)))
+  (skip-syntax-forward " ")
   (let* ((tmp (evilmi-sdk-jump-forward-p))
          (jump-forward (car tmp))
          ;; if ff is not nil, it's jump between quotes

--- a/tests/evil-matchit-tests.el
+++ b/tests/evil-matchit-tests.el
@@ -471,5 +471,17 @@
 
     (should (eq major-mode 'octave-mode))))
 
+(ert-deftest evilmi-test-simplejump-space ()
+  "`evilmi-sdk-simple-jump' should skip spaces."
+  (with-temp-buffer
+    (insert "    {
+    }")
+    (goto-char (point-min))
+    (evilmi-sdk-simple-jump)
+    (should (= (char-after) ?}))
+    (goto-line 2)
+    (evilmi-sdk-simple-jump)
+    (should (= (char-after) ?{))))
+
 (ert-run-tests-batch-and-exit)
 ;;; evil-matchit-tests.el ends here


### PR DESCRIPTION
If the cursor is placed on a group of whitespace followed by a closing item,
`evilmi-sdk-simple-jump` errors with a `scan-error`, due to calling
`scan-sexps`, which, after skipping whitespace, sees a prematurely terminated
expression (a close tag).

Fix that by making the function skip whitespace first, allowing it to see the
correct item character. This is consistent with `evil-jump-item'.

My issue was as follows (with `debug-on-error` enabled):
```java
// Java has no special evilmi-support
class X {
     public static void q(int y) {
     
/* cursor here, `evilmi-jump-items` errors */    }
}
```
With my PR, `evilmi-jump-items` jumps to the correct open brace.