### PR TITLE
`evilmi-sdk-simple-jump': skip comments

### DIFF
--- a/evil-matchit-sdk.el
+++ b/evil-matchit-sdk.el
@@ -153,7 +153,17 @@ If IS-FORWARD is t, jump forward; or else jump backward."
 (defun evilmi-sdk-simple-jump ()
   "Alternative for `evil-jump-item'."
   (if evilmi-debug (message "evilmi-sdk-simple-jump called (point)=%d" (point)))
-  (skip-syntax-forward " ")
+  (let ((old (point)))
+    (skip-syntax-forward " ")
+    ;; If we move from a non-comment to before a comment,
+    ;; `evilmi-sdk-jumpto-where' wont skip it:
+    ;;
+    ;; <point> /* comment */ {}
+    ;;
+    ;; Is skipped because we go back, but wouldn't be if we didn't (due to
+    ;; checking for `evilmi-sdk-comment-p').
+    (when (and (not (evilmi-sdk-comment-p old)) (evilmi-sdk-comment-p (point)))
+      (goto-char old)))
   (let* ((tmp (evilmi-sdk-jump-forward-p))
          (jump-forward (car tmp))
          ;; if ff is not nil, it's jump between quotes


### PR DESCRIPTION
After the previous change, if the cursor is before some whitespace followed by a
comment, the latter wouldn't be skipped as was the case previously. This is
because `evilmi-sdk-simple-jump` would skip to the comment, causing
`evilmi-sdk-jumpto-where` to no longer call `scan-sexp` with comment skipping
enabled.

Addresses point 1 [described here](https://github.com/redguardtoo/evil-matchit/pull/130#issuecomment-745101112).