### PR TITLE
Fix byte compiling

### DIFF
--- a/evil-matchit.el
+++ b/evil-matchit.el
@@ -48,6 +48,8 @@
 
 ;;; Code:
 
+(eval-when-compile
+  (require 'evil-macros))
 (require 'evil-matchit-sdk)
 
 (defvar evilmi-plugins '(emacs-lisp-mode ((evilmi-simple-get-tag evilmi-simple-jump)))


### PR DESCRIPTION
For some reason, I can no longer use a byte-compiled evil-matchit because the evil macros are not loaded. Adding this explicit require fixes the problem.