### PR TITLE
Support matlab-mode

### DIFF
--- a/evil-matchit.el
+++ b/evil-matchit.el
@@ -182,6 +182,7 @@ Some people prefer using \"m\" instead.")
 
   ;; Octave
   (evilmi-load-plugin-rules '(octave-mode) '(simple octave))
+  (evilmi-load-plugin-rules '(matlab-mode) '(simple octave))
 
   ;; Python
   (evilmi-load-plugin-rules '(python-mode) '(simple python))


### PR DESCRIPTION
Extend existing support for `octave-mode` to `matlab-mode` so that those who prefer `matlab-mode` to `octave-mode` can still enjoy `evil-matchit` goodness :)