### PR TITLE
Fix an issue where verilog identifiers could be matched as begin/end token

### DIFF
--- a/evil-matchit-verilog.el
+++ b/evil-matchit-verilog.el
@@ -64,7 +64,7 @@
   '(("^[ \t]*\\(while\\|module\\|primitive\\|case\\|function\\|specify\\|table\\|class\\|program\\|clocking\\|property\\|sequence\\|package\\|covergroup\\|generate\\|interface\\|task\\|fork\\|join[a-z]*\\)" 1)
     ("^[ \t]*\\(end[a-z]+\\)" 1)
     ("^[ \t]*\\(`[a-z]+\\)" 1) ; macro
-    ("\\([^a-z]\\|^\\)\\(begin\\|end\\)\\([^a-z]\\|$\\)" 2)))
+    ("\\([^a-zA-Z_]\\|^\\)\\(begin\\|end\\)\\([^a-zA-Z_]\\|$\\)" 2)))
 
 (defvar evilmi-verilog-match-tags
   '(("module" () "endmodule" "MONOGAMY")


### PR DESCRIPTION
Currently identifiers such as `foo_end`, `Xend`, `begin_foo`, etc will be considered begin/end tags in verilog. This PR makes the regex more restrictive so as to avoid matching identifiers most of the time. 