### PR TITLE
Enable JS/TS/HTML rules for tsx-ts-mode

### DIFF
--- a/evil-matchit.el
+++ b/evil-matchit.el
@@ -201,7 +201,8 @@ Some modes can be toggle on/off in the hook"
                               js2-jsx-mode
                               react-mode
                               typescript-mode
-                              typescript-tsx-mode)
+                              typescript-tsx-mode
+                              tsx-ts-mode)
                             '(simple javascript html))
 
   ;; Html


### PR DESCRIPTION
This PR makes evil-matchit support the new [tsx-ts-mode](https://github.com/emacs-mirror/emacs/blob/ac7ec87a7a0db887e4ae7fe9005aea517958b778/lisp/progmodes/typescript-ts-mode.el#L433) available in Emacs 29.