### PR TITLE
Make latex plugin also works for AUCTeX too

### DIFF
--- a/evil-matchit.el
+++ b/evil-matchit.el
@@ -221,7 +221,7 @@ Some modes can be toggle on/off in the hook"
   (evilmi-load-plugin-rules '(markdown-mode) '(markdown))
 
   ;; Latex
-  (evilmi-load-plugin-rules '(latex-mode) '(latex simple))
+  (evilmi-load-plugin-rules '(latex-mode LaTeX-mode) '(latex simple))
 
   ;; Ocaml
   (evilmi-load-plugin-rules '(tuareg-mode) '(simple ocaml))


### PR DESCRIPTION
Emacs now ship AUCTeX by default, so the default mode for latex is now provided by AUCTeX, named as LaTeX-mode, to replace the old latex-mode provided by tex.el.

In order to be compatible to people who use latex-mode, both shall be preserved. 