### PR TITLE
feat: html tag support for js/typescript treesitter modes

### DIFF
--- a/evil-matchit.el
+++ b/evil-matchit.el
@@ -195,11 +195,13 @@ Some modes can be toggle on/off in the hook"
                               js2-mode
                               js3-mode
                               javascript-mode
+                              js-ts-mode
                               rjsx-mode
                               js2-jsx-mode
                               react-mode
                               typescript-mode
                               typescript-tsx-mode
+                              typescript-ts-mode
                               tsx-ts-mode)
                             '(simple javascript html))
 


### PR DESCRIPTION
Adds missing 'tree sitter' version entries for typescript and javascript when setting up html tags match.