### PR TITLE
fix: make evilmi-jump-hook run after jump

### DIFF
--- a/evil-matchit.el
+++ b/evil-matchit.el
@@ -161,6 +161,7 @@ Some modes can be toggle on/off in the hook."
       (setq ideal-dest (point)))
 
     (if evilmi-debug (message "evilmi-jump-items-internal returned: %s" ideal-dest))
+    (run-hook-with-args 'evilmi-jump-hook nil)
     ideal-dest))
 
 ;;;###autoload


### PR DESCRIPTION
evilmi-jump-hook is intended to run before AND after a jump. However, the post-jump hook invocation was removed in commit 41a062bb88bde5aa3dc3ddab0ad5353e9bbc3f56. This change restores the missing call that runs the hook after a jump.